### PR TITLE
[DEV] 아이디, 닉네임, 이메일 중복 확인

### DIFF
--- a/src/main/java/org/example/springbootdeveloper/config/WebSecurityConfig.java
+++ b/src/main/java/org/example/springbootdeveloper/config/WebSecurityConfig.java
@@ -39,6 +39,8 @@ public class WebSecurityConfig {
         return http
                 .authorizeRequests()
                 .requestMatchers("/login", "/signup", "/user", "/mailConfirm").permitAll()
+                .requestMatchers("/auth/**").permitAll()
+
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/org/example/springbootdeveloper/controller/UserApiController.java
+++ b/src/main/java/org/example/springbootdeveloper/controller/UserApiController.java
@@ -9,10 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -27,6 +24,22 @@ public class UserApiController {
     public ResponseEntity<String> signup(@RequestBody AddUserRequest request) {
         userService.save(request); //회원 가입 메서드 호출
         return ResponseEntity.ok("User signed up successfully");
+    }
+
+    /* 아이디, 닉네임, 이메일 중복 체크 */
+    @GetMapping("/auth/id/{userId}/exists")
+    public ResponseEntity<Boolean> checkUserIdDuplicate(@PathVariable String userId){
+        return ResponseEntity.ok(userService.checkUsernameDuplication(userId));
+    }
+
+    @GetMapping("/auth/nickname/{nickname}/exists")
+    public ResponseEntity<Boolean> checkNicknameDuplicate(@PathVariable String nickname){
+        return ResponseEntity.ok(userService.checkUsernameDuplication(nickname));
+    }
+
+    @GetMapping("/auth/email/{email}/exists")
+    public ResponseEntity<Boolean> checkEmailDuplicate(@PathVariable String email){
+        return ResponseEntity.ok(userService.checkUsernameDuplication(email));
     }
 
 }

--- a/src/main/java/org/example/springbootdeveloper/repository/UserRepository.java
+++ b/src/main/java/org/example/springbootdeveloper/repository/UserRepository.java
@@ -7,5 +7,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(String userId); // UserId로 사용자 정보를 가져옴
+    boolean existsByUserId(String userId);
+    boolean existsByNickname(String nickname);
+    boolean existsByEmail(String email);
 
 }

--- a/src/main/java/org/example/springbootdeveloper/service/UserService.java
+++ b/src/main/java/org/example/springbootdeveloper/service/UserService.java
@@ -6,6 +6,7 @@ import org.example.springbootdeveloper.dto.AddUserRequest;
 import org.example.springbootdeveloper.repository.UserRepository;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -22,6 +23,29 @@ public class UserService {
                 .status(dto.getStatus())
                 .password(bCryptPasswordEncoder.encode(dto.getPassword()))
                 .build()).getId();
+    }
+
+    /* 아이디, 닉네임, 이메일 중복 여부 확인 */
+    @Transactional(readOnly = true)
+    //@Override
+    public boolean checkUsernameDuplication(String userId) {
+        boolean userIdDuplicate = userRepository.existsByUserId(userId);
+        return userIdDuplicate;
+    }
+
+    @Transactional(readOnly = true)
+    //@Override
+    public boolean checkNicknameDuplication(String nickname) {
+        boolean nicknameDuplicate = userRepository.existsByNickname(nickname);
+        return nicknameDuplicate;
+
+    }
+
+    @Transactional(readOnly = true)
+    //@Override
+    public boolean checkEmailDuplication(String email) {
+        boolean emailDuplicate = userRepository.existsByEmail(email);
+        return emailDuplicate;
     }
 
 }


### PR DESCRIPTION
## Summary
> 회원 가입 시 아이디, 닉네임, 이메일이 중복인지 각각 확인하는 api를 구현하였습니다. 

## Description
> - 아이디 중복 확인 api를 구현하였습니다. `/auth/id/{userId}/exists`의 형태로 `GET` 요청을 전송하면, 해당 아이디가 있다면 true, 없다면 false가 반환됩니다. 
> - 닉네임 중복 확인 api를 구현하였습니다. `/auth/nickname/{nickname}/exists`의 형태로 `GET` 요청을 전송하면, 해당 닉네임이 있다면 true, 없다면 false가 반환됩니다. 
> - 이메일 중복 확인 api를 구현하였습니다. `/auth/email/{email}/exists`의 형태로 `GET` 요청을 전송하면, 해당 이메일이 있다면 true, 없다면 false가 반환됩니다. 

