### PR TITLE
[DEV] 성향 조사 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,15 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="e3f4b2f5-1a43-49d9-b3bb-f5f9a6d39a78" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/dto/EmailAuthRequestDto.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/controller/TestController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/controller/UserStyleApiController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/domain/UserStyle.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/dto/AddUserStyleRequest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/repository/UserStyleRepository.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/service/StyleService.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/build.gradle.kts" beforeDir="false" afterPath="$PROJECT_DIR$/build.gradle.kts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/controller/EmailController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/controller/EmailController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/dto/EmailPostDto.java" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/dto/EmailResponseDto.java" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/service/EmailService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/service/EmailService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.yml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/templates/email.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/templates/email.html" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -28,6 +26,7 @@
   <component name="FileTemplateManagerImpl">
     <option name="RECENT_TEMPLATES">
       <list>
+        <option value="Interface" />
         <option value="Class" />
       </list>
     </option>
@@ -41,29 +40,29 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RequestMappingsPanelOrder0": "0",
-    "RequestMappingsPanelOrder1": "1",
-    "RequestMappingsPanelWidth0": "75",
-    "RequestMappingsPanelWidth1": "75",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "WebServerToolWindowFactoryState": "false",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_package_manager_path": "npm",
-    "onboarding.tips.debug.path": "/Users/baesumin/Desktop/capston_backend/mate_backend/src/main/java/org/example/Main.java",
-    "project.structure.last.edited": "Modules",
-    "project.structure.proportion": "0.0",
-    "project.structure.side.proportion": "0.0",
-    "settings.editor.selected.configurable": "http.proxy",
-    "spring.configuration.checksum": "28a93b9d03450515c6262d0b8f2e5c3a",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RequestMappingsPanelOrder0&quot;: &quot;0&quot;,
+    &quot;RequestMappingsPanelOrder1&quot;: &quot;1&quot;,
+    &quot;RequestMappingsPanelWidth0&quot;: &quot;75&quot;,
+    &quot;RequestMappingsPanelWidth1&quot;: &quot;75&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;onboarding.tips.debug.path&quot;: &quot;/Users/baesumin/Desktop/capston_backend/mate_backend/src/main/java/org/example/Main.java&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;Modules&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.0&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.0&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;http.proxy&quot;,
+    &quot;spring.configuration.checksum&quot;: &quot;28a93b9d03450515c6262d0b8f2e5c3a&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
       <recent name="org.example.springbootdeveloper.email.dto" />

--- a/src/main/java/org/example/springbootdeveloper/controller/TestController.java
+++ b/src/main/java/org/example/springbootdeveloper/controller/TestController.java
@@ -1,0 +1,15 @@
+package org.example.springbootdeveloper.controller;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class TestController {
+    @GetMapping("/test")
+    public String userName(){
+        String userName = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userName;
+    }
+
+
+}

--- a/src/main/java/org/example/springbootdeveloper/controller/UserStyleApiController.java
+++ b/src/main/java/org/example/springbootdeveloper/controller/UserStyleApiController.java
@@ -1,0 +1,27 @@
+package org.example.springbootdeveloper.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.springbootdeveloper.domain.UserStyle;
+import org.example.springbootdeveloper.dto.AddUserStyleRequest;
+import org.example.springbootdeveloper.service.StyleService;
+import org.example.springbootdeveloper.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+
+
+@RequiredArgsConstructor
+@RestController
+public class UserStyleApiController {
+    private final StyleService styleService;
+    @PostMapping("/style")
+    public ResponseEntity<String> addUserStyle(@RequestBody AddUserStyleRequest request, Principal principal) {
+        UserStyle savedUserStyle = styleService.save(request, principal.getName());
+        return ResponseEntity.ok("User style successfully");
+    }
+
+
+}

--- a/src/main/java/org/example/springbootdeveloper/domain/UserStyle.java
+++ b/src/main/java/org/example/springbootdeveloper/domain/UserStyle.java
@@ -1,0 +1,34 @@
+package org.example.springbootdeveloper.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name= "userstyles")
+public class UserStyle {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Column(name = "userId")
+    private String userId;
+
+    private String userAnimal;
+    private int bedtimeScore;
+    private int wakeupScore;
+
+    @Builder
+    public UserStyle(String userId, String userAnimal, int bedtimeScore, int wakeupScore){
+        this.userId = userId;
+        this.userAnimal = userAnimal;
+        this.bedtimeScore = bedtimeScore;
+        this.wakeupScore = wakeupScore;
+    }
+
+}

--- a/src/main/java/org/example/springbootdeveloper/dto/AddUserStyleRequest.java
+++ b/src/main/java/org/example/springbootdeveloper/dto/AddUserStyleRequest.java
@@ -1,0 +1,25 @@
+package org.example.springbootdeveloper.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.springbootdeveloper.domain.UserStyle;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class AddUserStyleRequest {
+    private String userId;
+    private String userAnimal;
+    private int bedtimeScore;
+    private int wakeupScore;
+
+    public UserStyle toEntity(String userId){
+        return UserStyle.builder()
+                .userId(userId)
+                .userAnimal(userAnimal)
+                .bedtimeScore(bedtimeScore)
+                .wakeupScore(wakeupScore)
+                .build();
+    }
+}

--- a/src/main/java/org/example/springbootdeveloper/repository/UserStyleRepository.java
+++ b/src/main/java/org/example/springbootdeveloper/repository/UserStyleRepository.java
@@ -1,0 +1,12 @@
+package org.example.springbootdeveloper.repository;
+
+import org.example.springbootdeveloper.domain.User;
+import org.example.springbootdeveloper.domain.UserStyle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserStyleRepository extends JpaRepository<UserStyle, Long> {
+    Optional<UserStyle> findByUserId(String userId); // UserId로 사용자 정보를 가져옴
+
+}

--- a/src/main/java/org/example/springbootdeveloper/service/StyleService.java
+++ b/src/main/java/org/example/springbootdeveloper/service/StyleService.java
@@ -1,0 +1,16 @@
+package org.example.springbootdeveloper.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.springbootdeveloper.domain.UserStyle;
+import org.example.springbootdeveloper.dto.AddUserStyleRequest;
+import org.example.springbootdeveloper.repository.UserStyleRepository;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class StyleService {
+    private final UserStyleRepository userStyleRepository;
+    public UserStyle save(AddUserStyleRequest request, String userId){
+        return userStyleRepository.save(request.toEntity(userId));
+    }
+}


### PR DESCRIPTION
## Summary
> 성향 조사 관련 API를 구성하였습니다. 

## Description
> - 성향 조사를 구현하였습니다. `/style`의 형태로 `POST` 요청을 전송하면, DB에 성향 조사 결과가 저장됩니다. 
> ```
> {
>   "userAnimal": "사용자 동물",
>   "bedtimeScore": 123,
>   "wakeupScore": 456
> }
>```

## 추후 수정 사항
> - 각 항목을 하나 하나의 API로 만들어 저장하는 기능으로 수정합니다.
> - 아직 항목을 2개로 만들어 test해보았습니다. 항목을 질문지의 개수에 맞게 수정합니다.