### PR TITLE
[DEV] 기숙사 인증 파일 업로드 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="e3f4b2f5-1a43-49d9-b3bb-f5f9a6d39a78" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/dorm_auth/FileController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/controller/UserAnimalController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/controller/UserAnimalController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/service/AnimalService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/service/AnimalService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/service/EmailService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/example/springbootdeveloper/email/service/EmailService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/application.yml" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/main/java/org/example/springbootdeveloper/config/WebSecurityConfig.java
+++ b/src/main/java/org/example/springbootdeveloper/config/WebSecurityConfig.java
@@ -38,7 +38,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeRequests()
-                .requestMatchers("/login", "/signup", "/user", "/mailConfirm", "/image").permitAll()
+                .requestMatchers("/login", "/signup", "/user", "/mailConfirm").permitAll()
                 .requestMatchers("/auth/**").permitAll()
 
                 .anyRequest().authenticated()

--- a/src/main/java/org/example/springbootdeveloper/config/WebSecurityConfig.java
+++ b/src/main/java/org/example/springbootdeveloper/config/WebSecurityConfig.java
@@ -38,7 +38,7 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .authorizeRequests()
-                .requestMatchers("/login", "/signup", "/user", "/mailConfirm").permitAll()
+                .requestMatchers("/login", "/signup", "/user", "/mailConfirm", "/image").permitAll()
                 .requestMatchers("/auth/**").permitAll()
 
                 .anyRequest().authenticated()

--- a/src/main/java/org/example/springbootdeveloper/dorm_auth/controller/FileController.java
+++ b/src/main/java/org/example/springbootdeveloper/dorm_auth/controller/FileController.java
@@ -1,0 +1,52 @@
+package org.example.springbootdeveloper.dorm_auth.controller;
+
+import org.example.springbootdeveloper.dorm_auth.domain.FileEntity;
+import org.example.springbootdeveloper.dorm_auth.repository.FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.*;
+import java.net.URLEncoder;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping()
+public class FileController {
+    private final FileRepository fileRepository;
+    String filepath = "/Users/baesumin/Desktop/capston_backend/mate_backend/src/main/resources/static/images";
+
+    /**
+     *  이미지 업로드
+     * @return Map<String, Object>
+     */
+    @PostMapping("/auth/image")
+    public FileEntity uploadImage(HttpServletRequest request,
+                                  @RequestParam(value="file", required = false) MultipartFile[] files) {
+
+        String FileNames = "";
+
+        String originFileName = files[0].getOriginalFilename();
+        long fileSize = files[0].getSize();
+        String safeFile = System.currentTimeMillis() + originFileName;
+
+        File f1 = new File(filepath + safeFile);
+        try {
+            files[0].transferTo(f1);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        final FileEntity file = FileEntity.builder()
+                .filename(safeFile)
+                .build();
+
+        return fileRepository.save(file);
+    }
+
+}
+

--- a/src/main/java/org/example/springbootdeveloper/dorm_auth/controller/FileController.java
+++ b/src/main/java/org/example/springbootdeveloper/dorm_auth/controller/FileController.java
@@ -11,6 +11,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.net.URLEncoder;
+import java.security.Principal;
 import java.util.List;
 
 @RestController
@@ -26,7 +27,7 @@ public class FileController {
      */
     @PostMapping("/auth/image")
     public FileEntity uploadImage(HttpServletRequest request,
-                                  @RequestParam(value="file", required = false) MultipartFile[] files) {
+                                  @RequestParam(value="file", required = false) MultipartFile[] files, Principal principal) {
 
         String FileNames = "";
 
@@ -43,6 +44,7 @@ public class FileController {
 
         final FileEntity file = FileEntity.builder()
                 .filename(safeFile)
+                .user_id(principal.getName())
                 .build();
 
         return fileRepository.save(file);

--- a/src/main/java/org/example/springbootdeveloper/dorm_auth/domain/FileEntity.java
+++ b/src/main/java/org/example/springbootdeveloper/dorm_auth/domain/FileEntity.java
@@ -1,0 +1,23 @@
+package org.example.springbootdeveloper.dorm_auth.domain;
+
+import lombok.*;
+
+import jakarta.persistence.*;
+import java.util.Date;
+
+@Getter // getter 메소드 생성
+@Builder // 빌더를 사용할 수 있게 함
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name="file") // 테이블 명을 작성
+public class FileEntity {
+    @Id // primary key임을 명시
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long pid;
+
+    @Column(nullable = false, unique = true, length = 1000)
+    private String filename;
+
+    @Column(nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private String created_dt;
+}

--- a/src/main/java/org/example/springbootdeveloper/dorm_auth/domain/FileEntity.java
+++ b/src/main/java/org/example/springbootdeveloper/dorm_auth/domain/FileEntity.java
@@ -18,6 +18,9 @@ public class FileEntity {
     @Column(nullable = false, unique = true, length = 1000)
     private String filename;
 
+    @Column(nullable = false, updatable = false)
+    private String user_id;
+
     @Column(nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private String created_dt;
 }

--- a/src/main/java/org/example/springbootdeveloper/dorm_auth/repository/FileRepository.java
+++ b/src/main/java/org/example/springbootdeveloper/dorm_auth/repository/FileRepository.java
@@ -1,0 +1,10 @@
+package org.example.springbootdeveloper.dorm_auth.repository;
+
+import org.example.springbootdeveloper.dorm_auth.domain.FileEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FileRepository extends JpaRepository<FileEntity, Long> {
+
+}

--- a/src/main/java/org/example/springbootdeveloper/email/service/EmailService.java
+++ b/src/main/java/org/example/springbootdeveloper/email/service/EmailService.java
@@ -48,7 +48,7 @@ public class EmailService {
     public MimeMessage createEmailForm(String email) throws MessagingException, UnsupportedEncodingException {
 
         createCode(); //인증 코드 생성
-        String setFrom = "rnqhstlr2297@naver.com"; //email-config에 설정한 자신의 이메일 주소(보내는 사람)
+        String setFrom = "baesoomin6@gmail.com"; //email-config에 설정한 자신의 이메일 주소(보내는 사람)
         String toEmail = email; //받는 사람
         String title = "Aniroomy 회원가입 인증 번호"; //제목
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,3 +26,5 @@ spring:
             enable: true
           auth: true
 
+
+


### PR DESCRIPTION
## Summary
> 기숙사 인증에 필요한 이미지 파일을 업로드 하는 api를 구현했습니다. 

## Description
> - 이미지 업로드 api를 구현했습니다. `/auth/image`의 형태로 `POST` 요청과 함께 form-data 형식으로 파일을 전송하면, 해당 파일이 서버에 임시 저장됩니다.
